### PR TITLE
URL Cleanup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -42,6 +42,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 image:https://circleci.com/gh/spring-cloud/spring-cloud-cli.svg?style=svg["CircleCI", link="https://circleci.com/gh/spring-cloud/spring-cloud-cli"]
 
-Spring Boot CLI provides http://projects.spring.io/spring-boot[Spring
+Spring Boot CLI provides https://projects.spring.io/spring-boot[Spring
 Boot] command line features for https://github.com/spring-cloud[Spring
 Cloud]. You can write Groovy scripts to run Spring Cloud component
 applications (e.g. `@EnableEurekaServer`). You can also easily do
@@ -80,7 +80,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -102,13 +102,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -164,7 +164,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -177,6 +177,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/docs/src/main/asciidoc/intro.adoc
+++ b/docs/src/main/asciidoc/intro.adoc
@@ -1,4 +1,4 @@
-Spring Boot CLI provides http://projects.spring.io/spring-boot[Spring
+Spring Boot CLI provides https://projects.spring.io/spring-boot[Spring
 Boot] command line features for https://github.com/spring-cloud[Spring
 Cloud]. You can write Groovy scripts to run Spring Cloud component
 applications (e.g. `@EnableEurekaServer`). You can also easily do

--- a/spring-cloud-cli/src/main/java/org/springframework/cloud/cli/compiler/JavaVersion.java
+++ b/spring-cloud-cli/src/main/java/org/springframework/cloud/cli/compiler/JavaVersion.java
@@ -22,8 +22,8 @@ import java.util.List;
  * TAKEN FROM GRADLE (https://github.com/gradle/gradle/blob/master/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java)
  *
  * An enumeration of Java versions.
- * Before 9: http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
- * 9+: http://openjdk.java.net/jeps/223
+ * Before 9: https://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
+ * 9+: https://openjdk.java.net/jeps/223
  */
 enum JavaVersion {
 	VERSION_1_1, VERSION_1_2, VERSION_1_3, VERSION_1_4,

--- a/spring-cloud-launcher/README.md
+++ b/spring-cloud-launcher/README.md
@@ -49,7 +49,7 @@ To run configserver with a git repo set the following in `./configserver.yml`:
 ```yaml
 spring:
   profiles.active: git
-  cloud.config.server.git.uri: http://mygitserver/myrepo.git
+  cloud.config.server.git.uri: https://mygitserver/myrepo.git
 ```
 
 ### Stopping


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://mygitserver/myrepo.git (UnknownHostException) with 1 occurrences migrated to:  
  https://mygitserver/myrepo.git ([https](https://mygitserver/myrepo.git) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://openjdk.java.net/jeps/223 with 1 occurrences migrated to:  
  https://openjdk.java.net/jeps/223 ([https](https://openjdk.java.net/jeps/223) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 2 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html ([https](https://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 2 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://projects.spring.io/spring-boot with 2 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences
* http://localhost:7979 with 1 occurrences
* http://localhost:8080/eureka/ with 2 occurrences
* http://localhost:8750 with 1 occurrences
* http://localhost:8750/stubs with 2 occurrences
* http://localhost:8761 with 2 occurrences
* http://localhost:8761/eureka/ with 2 occurrences
* http://localhost:8888 with 1 occurrences
* http://localhost:9091 with 1 occurrences
* http://localhost:9095 with 2 occurrences
* http://localhost:9393 with 1 occurrences
* http://localhost:9411 with 1 occurrences