### PR TITLE
URL Cleanup

### DIFF
--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="http://www.w3.org/2000/svg">
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="https://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>
 <font id="fontawesomeregular" horiz-adv-x="1536" >

--- a/spring-cloud-cli.xml
+++ b/spring-cloud-cli.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Boot Cloud CLI</title>
 <date>2019-03-25</date>
 </info>
 <preface>
 <title></title>
-<simpara>Spring Boot CLI provides <link xl:href="http://projects.spring.io/spring-boot">Spring
+<simpara>Spring Boot CLI provides <link xl:href="https://projects.spring.io/spring-boot">Spring
 Boot</link> command line features for <link xl:href="https://github.com/spring-cloud">Spring
 Cloud</link>. You can write Groovy scripts to run Spring Cloud component
 applications (e.g. <literal>@EnableEurekaServer</literal>). You can also easily do
@@ -70,50 +70,50 @@ just list them on the command line, e.g.</simpara>
 <row>
 <entry align="left" valign="top"><simpara>eureka</simpara></entry>
 <entry align="left" valign="top"><simpara>Eureka Server</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://localhost:8761">http://localhost:8761</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://localhost:8761">https://localhost:8761</link></simpara></entry>
 <entry align="left" valign="top"><simpara>Eureka server for service registration and discovery. All the other services show up in its catalog by default.</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>configserver</simpara></entry>
 <entry align="left" valign="top"><simpara>Config Server</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://localhost:8888">http://localhost:8888</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://localhost:8888">https://localhost:8888</link></simpara></entry>
 <entry align="left" valign="top"><simpara>Spring Cloud Config Server running in the "native" profile and serving configuration from the local directory ./launcher</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>h2</simpara></entry>
 <entry align="left" valign="top"><simpara>H2 Database</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://localhost:9095">http://localhost:9095</link> (console), jdbc:h2:tcp://localhost:9096/{data}</simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://localhost:9095">https://localhost:9095</link> (console), jdbc:h2:tcp://localhost:9096/{data}</simpara></entry>
 <entry align="left" valign="top"><simpara>Relation database service. Use a file path for <literal>{data}</literal> (e.g. <literal>./target/test</literal>) when you connect. Remember that you can add <literal>;MODE=MYSQL</literal> or <literal>;MODE=POSTGRESQL</literal> to connect with compatibility to other server types.</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>kafka</simpara></entry>
 <entry align="left" valign="top"><simpara>Kafka Broker</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://localhost:9091">http://localhost:9091</link> (actuator endpoints), localhost:9092</simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://localhost:9091">https://localhost:9091</link> (actuator endpoints), localhost:9092</simpara></entry>
 <entry align="left" valign="top"></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>hystrixdashboard</simpara></entry>
 <entry align="left" valign="top"><simpara>Hystrix Dashboard</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://localhost:7979">http://localhost:7979</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://localhost:7979">https://localhost:7979</link></simpara></entry>
 <entry align="left" valign="top"><simpara>Any Spring Cloud app that declares Hystrix circuit breakers publishes metrics on <literal>/hystrix.stream</literal>. Type that address into the dashboard to visualize all the metrics,</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>dataflow</simpara></entry>
 <entry align="left" valign="top"><simpara>Dataflow Server</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://localhost:9393">http://localhost:9393</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://localhost:9393">https://localhost:9393</link></simpara></entry>
 <entry align="left" valign="top"><simpara>Spring Cloud Dataflow server with UI at /admin-ui. Connect the Dataflow shell to target at root path.</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>zipkin</simpara></entry>
 <entry align="left" valign="top"><simpara>Zipkin Server</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://localhost:9411">http://localhost:9411</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://localhost:9411">https://localhost:9411</link></simpara></entry>
 <entry align="left" valign="top"><simpara>Zipkin Server with UI for visualizing traces. Stores span data in memory and accepts them via HTTP POST of JSON data.</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>stubrunner</simpara></entry>
 <entry align="left" valign="top"><simpara>Stub Runner Boot</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://localhost:8750">http://localhost:8750</link></simpara></entry>
-<entry align="left" valign="top"><simpara>Downloads WireMock stubs, starts WireMock and feeds the started servers with stored stubs. Pass <literal>stubrunner.ids</literal> to pass stub coordinates and then go to <literal><link xl:href="http://localhost:8750/stubs">http://localhost:8750/stubs</link></literal>.</simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://localhost:8750">https://localhost:8750</link></simpara></entry>
+<entry align="left" valign="top"><simpara>Downloads WireMock stubs, starts WireMock and feeds the started servers with stored stubs. Pass <literal>stubrunner.ids</literal> to pass stub coordinates and then go to <literal><link xl:href="https://localhost:8750/stubs">https://localhost:8750/stubs</link></literal>.</simpara></entry>
 </row>
 </tbody>
 </tgroup>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://localhost:7979 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost:7979 ([https](https://localhost:7979) result AnnotatedConnectException).
* [ ] http://localhost:8750 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost:8750 ([https](https://localhost:8750) result AnnotatedConnectException).
* [ ] http://localhost:8750/stubs (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost:8750/stubs ([https](https://localhost:8750/stubs) result AnnotatedConnectException).
* [ ] http://localhost:8761 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost:8761 ([https](https://localhost:8761) result AnnotatedConnectException).
* [ ] http://localhost:8888 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost:8888 ([https](https://localhost:8888) result AnnotatedConnectException).
* [ ] http://localhost:9091 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost:9091 ([https](https://localhost:9091) result AnnotatedConnectException).
* [ ] http://localhost:9095 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost:9095 ([https](https://localhost:9095) result AnnotatedConnectException).
* [ ] http://localhost:9393 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost:9393 ([https](https://localhost:9393) result AnnotatedConnectException).
* [ ] http://localhost:9411 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost:9411 ([https](https://localhost:9411) result AnnotatedConnectException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docbook.org/ns/docbook with 1 occurrences migrated to:  
  https://docbook.org/ns/docbook ([https](https://docbook.org/ns/docbook) result 200).
* [ ] http://www.w3.org/1999/xlink with 1 occurrences migrated to:  
  https://www.w3.org/1999/xlink ([https](https://www.w3.org/1999/xlink) result 200).
* [ ] http://www.w3.org/2000/svg with 1 occurrences migrated to:  
  https://www.w3.org/2000/svg ([https](https://www.w3.org/2000/svg) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://projects.spring.io/spring-boot with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).