### PR TITLE
URL Cleanup

### DIFF
--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-cli.xml
+++ b/spring-cloud-cli.xml
@@ -8,7 +8,7 @@
 </info>
 <preface>
 <title></title>
-<simpara>Spring Boot CLI provides <link xl:href="http://projects.spring.io/spring-boot">Spring
+<simpara>Spring Boot CLI provides <link xl:href="https://projects.spring.io/spring-boot">Spring
 Boot</link> command line features for <link xl:href="https://github.com/spring-cloud">Spring
 Cloud</link>. You can write Groovy scripts to run Spring Cloud component
 applications (e.g. <literal>@EnableEurekaServer</literal>). You can also easily do


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://projects.spring.io/spring-boot with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 1 occurrences
* http://localhost:7979 with 2 occurrences
* http://localhost:8750 with 2 occurrences
* http://localhost:8750/stubs with 2 occurrences
* http://localhost:8761 with 2 occurrences
* http://localhost:8888 with 2 occurrences
* http://localhost:9091 with 2 occurrences
* http://localhost:9095 with 2 occurrences
* http://localhost:9393 with 2 occurrences
* http://localhost:9411 with 2 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences
* http://www.w3.org/2000/svg with 1 occurrences