### PR TITLE
Incorrect reference to Boot

### DIFF
--- a/docs/src/main/asciidoc/intro.adoc
+++ b/docs/src/main/asciidoc/intro.adoc
@@ -1,4 +1,4 @@
-Spring Boot CLI provides https://projects.spring.io/spring-boot[Spring
+https://cloud.spring.io/spring-cloud-cli/[Spring Cloud CLI] provides https://projects.spring.io/spring-boot[Spring
 Boot] command line features for https://github.com/spring-cloud[Spring
 Cloud]. You can write Groovy scripts to run Spring Cloud component
 applications (e.g. `@EnableEurekaServer`). You can also easily do


### PR DESCRIPTION
Introduction incorrectly mentions Spring Boot CLI where it should be talking about Sprint Cloud CLI.